### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "dev", "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/fj604/shakespearean-insult-api/security/code-scanning/1](https://github.com/fj604/shakespearean-insult-api/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily involves building and running a Docker container, it likely only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents, minimizing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
